### PR TITLE
adding eavejester/environ for environment setting of api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ pom.xml.asc
 .lein-repl-history
 .lein-plugins/
 .lein-failures
+.lein-env
 .nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
                  [aleph "0.4.0-beta3"]
                  [clj-http "1.1.0"]
                  [cheshire "5.4.0"]
-                 [overtone/at-at "1.2.0"]])
+                 [overtone/at-at "1.2.0"]
+                 [environ "1.0.0"]])

--- a/src/deadbeat/core.clj
+++ b/src/deadbeat/core.clj
@@ -1,11 +1,10 @@
 (ns deadbeat.core
   (:require
-    [clj-http.client :as client]
-    [deadbeat.slack.api :as api]
     [deadbeat.slack.rtm :as rtm]
+    [environ.core :as environ]
     [clojure.core.async :as a :refer [go chan <! >!]]))
 
-(def hardcode-token "...")
+(def hardcode-token (environ/env :api-token))
 
 (defn print-message [{:keys [user text]}]
   (println (:name user) ": " text))


### PR DESCRIPTION
Instead of having the api token being hardcoded in the source, Environ will allow you to use environment settings for configuration values.
